### PR TITLE
Multiprocessing bug

### DIFF
--- a/MABOS_core/sensor_manager.py
+++ b/MABOS_core/sensor_manager.py
@@ -49,6 +49,9 @@ class SensorManager:
         :param save_data: boolean flag. If true, save acquired data to file and RAM, if not just update it in RAM
         :return: pointer to process
         """
+        # Ensures all resources available to parent process are identical to child process. Needed for windows & macOS
+        multiprocessing.set_start_method('fork')
+
         if save_data:
             p = multiprocessing.Process(name='update',
                                         target=update_save_data,

--- a/MABOS_core/sensor_manager.py
+++ b/MABOS_core/sensor_manager.py
@@ -18,7 +18,12 @@ class SensorManager:
         :param window_size: for 1D data, number of timepoints to acquire before passing
         :param baudrate: target baudrate
         """
+
+        # Ensures all resources available to parent process are identical to child process. Needed for windows & macOS
+        multiprocessing.set_start_method('fork')
+
         mutex = create_mutex()
+
         self.ser = setup_serial(commport, baudrate)
         self.window_size = window_size
         self.shm, data_shared, self.plot = create_shared_block(grid_plot_flag=True,
@@ -49,8 +54,6 @@ class SensorManager:
         :param save_data: boolean flag. If true, save acquired data to file and RAM, if not just update it in RAM
         :return: pointer to process
         """
-        # Ensures all resources available to parent process are identical to child process. Needed for windows & macOS
-        multiprocessing.set_start_method('fork')
 
         if save_data:
             p = multiprocessing.Process(name='update',

--- a/examples/MABOS_PPG.ipynb
+++ b/examples/MABOS_PPG.ipynb
@@ -10,7 +10,19 @@
     "from MABOS_core import SensorManager\n",
     "from MABOS_core import plot_manager as pm\n",
     "from MABOS_core import strg_manager\n",
+    "from MABOS_core import ser_manager\n",
     "from functools import partial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a1340c0-312f-4edf-9061-c8f773edac21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find available serial ports\n",
+    "ser_manager.find_serial()"
    ]
   },
   {


### PR DESCRIPTION
Set multiprocessing default for 'fork', not 'spawn' so all parent process information is by default available for all child processes